### PR TITLE
docs: signpost EFM guide moved to EdgeFlowManager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,13 @@ Repo homes vary per device — see `CLAUDE-CHECKIN.md` for the current per-host 
 | Repo | What it is |
 |---|---|
 | DesktopShare (this) | Docs, plans, cross-environment golden source. **Not** where app code lives. |
+| **EdgeFlowManager** | **The published Complete Guide to Edge Flow Management** — chapters, EFM/MiNiFi flow exports, and figures. Extracted from DesktopShare 2026-08-05; the guide index is its `README.md`. |
 | cso-operator-app | The Streamers / RAG app. Has its own `CLAUDE.md` — read it before touching that repo. |
 | nifi-custom-processors | Local-only, not git-tracked. Custom NiFi Python processors. |
 | ClouderaStreamingOperators, NiFi2-Processor-Playground, MiNiFi-Kubernetes-Playground | The Cloudera-side yamls, MiNiFi playground, custom processor playground. |
+
+> **⚠️ The EFM guide moved to its own repo (2026-08-05): [`EdgeFlowManager`](https://github.com/cldr-steven-matison/EdgeFlowManager).**
+> DesktopShare's `guide/` is now only a redirect stub — **do not edit chapters, flows, or figures there.** All guide work (chapters, `files/efm*` flow exports, EFM screenshots) now happens in **EdgeFlowManager**. DesktopShare keeps only the internal source/planning docs — the `Complete Guide to Edge Flow Management.md` tracker, `efm-guide-summary.md`, and the `efm-*` / `minifi-*` source docs — as the working record.
 
 ## Escalations
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,6 +44,7 @@ hostname. Full specs and per-device paths: `CLAUDE-CHECKIN.md`.
 ## Repos (homes vary per device — see `CLAUDE-CHECKIN.md`)
 
 - **DesktopShare** (this) — docs, plans, cross-environment golden source. **Not** app code.
+- **EdgeFlowManager** — the published Complete Guide to Edge Flow Management (chapters, EFM/MiNiFi flow exports, figures). EFM guide work lives here now, **not** in DesktopShare's `guide/` (a redirect stub since 2026-08-05).
 - **cso-operator-app** — the Streamers / RAG control-plane app; has its own `CLAUDE.md`.
 - **nifi-custom-processors** — local-only custom NiFi Python processors (not git-tracked).
 - **ClouderaStreamingOperators**, **MiNiFi-Kubernetes-Playground**, **NiFi2 Processor Playground**
@@ -59,8 +60,9 @@ hostname. Full specs and per-device paths: `CLAUDE-CHECKIN.md`.
   gates on Steven's review). Full protocol: `agent/device-comms.md`.
 - **Promotion flow** — content moves DesktopShare root (in-progress) → `completed/` (done
   iterating) → `blog/` (polished draft) → blog repo `_posts/` (published).
-- **The guide** — `Complete Guide to Edge Flow Management.md`, the master EFM plan/index;
-  chapters are numbered only there.
+- **The guide** — the Complete Guide to Edge Flow Management, now published in its own repo
+  **EdgeFlowManager** (all guide work happens there). `Complete Guide to Edge Flow Management.md`
+  stays here as the internal tracker/plan of record; chapters are numbered only in the guide.
 - **Streamers** — the cso-operator-app pipeline that generates and posts stream content
   (Twitch/Kick/X); has a live pending/published queue governed by `agent/live-queues.md`.
 - **Live state outranks docs** — the cardinal rule: dump live `flow.json.gz`, hit health

--- a/Complete Guide to Edge Flow Management.md
+++ b/Complete Guide to Edge Flow Management.md
@@ -2,15 +2,14 @@
 
 *by Steven Matison*
 
-> **Reader entry point → [`guide/index.md`](guide/index.md).** That is the navigable guide (intro +
-> table of contents + folded chapters). This document is the **tracker of record** — per-chapter
-> status, sources, field-validation notes, and open issues.
+> **The published guide has moved → https://github.com/cldr-steven-matison/EdgeFlowManager** (extracted 2026-08-05).
+> The navigable guide (all chapters, figures, and runnable artifacts) now lives in that repo, where its
+> `README.md` is the reader entry point. DesktopShare's `guide/` is only a redirect stub — **do all guide
+> work in EdgeFlowManager**, not here.
 >
-> **Published form (decided [#72](https://github.com/cldr-steven-matison/DesktopShare/issues/72), 2026-08-03).**
-> The guide's published form is the `guide/` chapter set read through `guide/index.md`, in this repo —
-> not a single assembled document, and not a separate published site. This tracker's "living document /
-> master plan" framing retires once the last chapter folds; until then it stays the status-of-record and
-> `guide/index.md` is the reader artifact.
+> This document stays here as the **internal tracker of record** — per-chapter status, sources,
+> field-validation notes, and open issues. The `ch guide/chNN-....md` cells below record where each
+> chapter's prose was folded *before* the extraction.
 
 ![Cloudera Data in Motion — MiNiFi edge devices feeding NiFi, Kafka, and Flink for ingest and transform, into data-at-rest and AI/analytics, over the SDX security and governance layer](/images/efm-cloudera-edge-management.png)
 


### PR DESCRIPTION
Tells every device (via the session-start docs) that EFM guide work now happens in https://github.com/cldr-steven-matison/EdgeFlowManager , not DesktopShare's guide/ stub. Updates CLAUDE.md (repo table + callout), CONTEXT.md (repos + glossary), and the tracker's reader-entry pointer.